### PR TITLE
Update codecov.yml to get simpar from MPN

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,22 +19,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: metrumresearchgroup/actions/mpn-latest@v1
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
-      - name: Install dependencies
-        run: install.packages("simpar",repos="https://mpn.metworx.com/snapshots/stable/2024-09-23")
-        shell: Rscript {0}
+          extra-repositories: 'https://mpn.metworx.com/snapshots/stable/${{ env.MPN_LATEST }}'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, any::simpar
           needs: coverage
 
       - name: Test coverage
         run: |
-          options(repos = c(MPN = "https://mpn.metworx.com/snapshots/stable/2024-06-12", getOption("repos")))
           cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
@@ -54,8 +52,6 @@ jobs:
       - name: Show testthat output
         if: always()
         run: |
-          ## Rscript "writeLines('options(repos = c(MPN = \"https://mpn.metworx.com/snapshots/stable/2024-09-23\", getOption("repos")))', file('~/.Rprofile', 'ab'))"
-          ## --------------------------------------------------------------------
           find '${{ runner.temp }}/NMsim' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
@@ -65,6 +61,3 @@ jobs:
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/NMsim
-
-
-    


### PR DESCRIPTION
1. Added the MPN latest action to get the latest snapshot
2. Added the MPN repository to setup-r using the extra-repositories parameter
3. Removed the manual simpar installation step since it will now be handled by setup-r-dependencies
4. Added simpar to the extra-packages list in setup-r-dependencies
5. Removed the manual repository setting in the test coverage step since it's now handled at the R setup level